### PR TITLE
Fix broken EGI links and vscode linter compatibility

### DIFF
--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -16,6 +16,9 @@
     },
     {
       "pattern": "https://github.com/interTwin-eu/REPOSITORY/issues/new"
+    },
+    {
+      "pattern": "https://github.com/interTwin-eu/REPOSITORY/graphs/contributors"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "markdownlint.config": {
+        "MD013": {
+            "line_length": 120,
+            "code_blocks": false,
+            "tables": false
+          },
+          "MD014": false,
+          "MD024": false,
+          "MD026": {
+            "punctuation": ".,:;!"
+          }
+    }
+}

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,8 +2,8 @@
 
 ## Maintainers
 
-Full Name <email>
+Full Name \<email\>
 
 ## Contributors
 
-[All contributors](https://github.com/EGI-Federation/<REPOSITORY>/graphs/contributors)
+[All contributors](https://github.com/interTwin-eu/REPOSITORY/graphs/contributors)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ contribute are also welcome.
 ## Feedback and Questions
 
 If you wish to discuss anything related to the project, please open a
-[GitHub issue](https://github.com/EGI-Federation/REPOSITORY/issues/new).
+[GitHub issue](https://github.com/interTwin-eu/REPOSITORY/issues/new).
 
 ## Contribution Process
 


### PR DESCRIPTION
# Summary

Apparently, some links were inherited by previous EGI project templates. 
Furthremore, replicating the GH linter settings (`.github/linters/.markdownlint.json`) into `.vscode/` workspace settings improves compatibility with VS Code's markdown linter
